### PR TITLE
Update blockchain.bib

### DIFF
--- a/blockchain.bib
+++ b/blockchain.bib
@@ -7718,13 +7718,6 @@ url = {https://arxiv.org/pdf/1910.02059.pdf},
   url = {https://arxiv.org/pdf/1910.02218.pdf}, 
 }
 
-@misc{cryptoeprint:2019:1110,
-    author = {Jing Xu and Xinyu Li and Lingyuan Yin and Bingyong Guo and Han Feng and Zhenfeng Zhang},
-    title = {Redactable Proof-of-Stake Blockchain with Fast Confirmation},
-    howpublished = {Cryptology ePrint Archive, Report 2019/1110},
-    year = {2019},
-    url = {https://eprint.iacr.org/2019/1110.pdf},
-}
 
 @misc{zamyatin2019sok,
   title={SoK: Communication Across Distributed Ledgers},


### PR DESCRIPTION
We have withdrawn our paper in 3 Mar 2021. Now we have revised the paper with great changes and want to submit to some journal, and we want to withdraw the old version from Blocks & Chains Bibliography since it may affect the result of plagiarism detection.

Could you help me delete the cashed pdf? thanks!
@kernoelpanic 