### PR TITLE
Update blockchain.bib

### DIFF
--- a/blockchain.bib
+++ b/blockchain.bib
@@ -7043,14 +7043,6 @@ Published: IEEE Wireless Communications, 2020}
 	note = {Publication Title: arXiv preprint arXiv:1909.10645}
 }
 
-@book{xu2019redactable,
-	title = {Redactable {Proof}-of-{Stake} {Blockchain} with {Fast} {Confirmation}},
-	url = {https://eprint.iacr.org/2019/1110.pdf},
-	author = {Xu, Jing and Li, Xinyu and Yin, Lingyuan and Guo, Bingyong and Feng, Han and Zhang, Zhenfeng},
-	year = {2019},
-	note = {Published: Cryptology ePrint Archive, Report 2019/1110}
-}
-
 @book{ford2019rationality,
 	title = {Rationality is {Self}-{Defeating} in {Permissionless} {Systems}},
 	url = {https://arxiv.org/pdf/1910.08820.pdf},


### PR DESCRIPTION
We have withdrawn our paper in 3 Mar 2021. Now we have revised the paper with great changes and want to submit to some journal, and we want to withdraw the old version from Blocks & Chains Bibliography since it may affect the result of plagiarism detection. 

Could you help me delete the cashed pdf? thanks!
@kernoelpanic 